### PR TITLE
Create sqlite nodes with bun native

### DIFF
--- a/examples/sqlite-example.ts
+++ b/examples/sqlite-example.ts
@@ -1,0 +1,124 @@
+import { Effect } from "effect";
+import {
+  sqliteIngress,
+  sqliteSelect,
+  sqliteEgress,
+  sqliteInsert,
+  sqliteUpdate,
+} from "../src/nodes/index";
+
+// Example: Using SQLite nodes with Bun's native SQLite API
+
+async function sqliteNodesExample() {
+  console.log("🗃️  SQLite Nodes Example using Bun's native SQLite API");
+
+  const dbPath = "example.db";
+
+  // 1. Create a database and some test data
+  console.log("\n1. Setting up database with test data...");
+  const setupEgress = sqliteEgress("setup", {
+    dbPath,
+    query: `
+      CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT UNIQUE,
+        age INTEGER
+      )
+    `,
+  });
+
+  await Effect.runPromise(setupEgress.run([]));
+
+  // 2. Insert some users using sqliteInsert
+  console.log("\n2. Inserting users with sqliteInsert...");
+  const insertUsers = sqliteInsert("insert-users", {
+    dbPath,
+    table: "users",
+  });
+
+  const userData = [
+    { name: "Alice", email: "alice@example.com", age: 30 },
+    { name: "Bob", email: "bob@example.com", age: 25 },
+    { name: "Charlie", email: "charlie@example.com", age: 35 },
+  ];
+
+  const insertResult = await Effect.runPromise(insertUsers.run(userData));
+  console.log(`Inserted ${insertResult.changes} users`);
+
+  // 3. Query users using sqliteSelect
+  console.log("\n3. Querying all users with sqliteSelect...");
+  const selectAllUsers = sqliteSelect("select-all", {
+    dbPath,
+    query: "SELECT * FROM users ORDER BY name",
+  });
+
+  const allUsers = await Effect.runPromise(selectAllUsers.run(undefined));
+  console.log("All users:", allUsers);
+
+  // 4. Query with parameters using sqliteIngress
+  console.log("\n4. Querying users over 30 with sqliteIngress...");
+  const selectOlderUsers = sqliteIngress("select-older", {
+    dbPath,
+    query: "SELECT name, age FROM users WHERE age > ? ORDER BY age",
+    params: [30],
+  });
+
+  const olderUsersResult = await Effect.runPromise(
+    selectOlderUsers.run(undefined)
+  );
+  console.log("Users over 30:", olderUsersResult.rows);
+
+  // 5. Update a user using sqliteUpdate
+  console.log("\n5. Updating Alice's age with sqliteUpdate...");
+  const updateUser = sqliteUpdate("update-alice", {
+    dbPath,
+    table: "users",
+    setClause: "age = ?",
+    whereClause: "name = ?",
+  });
+
+  const updateResult = await Effect.runPromise(updateUser.run([31, "Alice"]));
+  console.log(`Updated ${updateResult.changes} record(s)`);
+
+  // 6. Verify the update
+  console.log("\n6. Verifying update...");
+  const selectUpdatedUser = sqliteSelect("select-alice", {
+    dbPath,
+    query: "SELECT name, age FROM users WHERE name = 'Alice'",
+  });
+
+  const updatedUser = await Effect.runPromise(
+    selectUpdatedUser.run(undefined)
+  );
+  console.log("Updated user:", updatedUser[0]);
+
+  // 7. Insert with custom query using sqliteEgress
+  console.log("\n7. Inserting a new user with custom query...");
+  const customInsert = sqliteEgress("custom-insert", {
+    dbPath,
+    query: "INSERT INTO users (name, email, age) VALUES (?, ?, ?)",
+  });
+
+  const customInsertResult = await Effect.runPromise(
+    customInsert.run(["David", "david@example.com", 28])
+  );
+  console.log(
+    `Inserted user with ID: ${customInsertResult.lastInsertRowid}`
+  );
+
+  // 8. Final count
+  console.log("\n8. Final user count...");
+  const countUsers = sqliteSelect("count-users", {
+    dbPath,
+    query: "SELECT COUNT(*) as count FROM users",
+  });
+
+  const countResult = await Effect.runPromise(countUsers.run(undefined));
+  console.log(`Total users: ${countResult[0].count}`);
+
+  console.log("\n✅ SQLite nodes example completed successfully!");
+}
+
+// Run the example
+sqliteNodesExample().catch(console.error);

--- a/src/nodes/egress/sqlite.test.ts
+++ b/src/nodes/egress/sqlite.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Effect } from "effect";
+import { sqliteEgress, sqliteInsert, sqliteUpdate } from "./sqlite";
+import { NodeKind } from "../../core/node";
+
+describe("SQLite Egress Nodes", () => {
+  const testDbPath = "test-egress.db";
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(testDbPath);
+    // Drop and recreate table to ensure clean state
+    db.exec("DROP TABLE IF EXISTS users");
+    db.exec(`
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT UNIQUE,
+        age INTEGER
+      )
+    `);
+    db.close();
+  });
+
+  describe("sqliteEgress", () => {
+    it("should create a node with correct properties", () => {
+      const node = sqliteEgress("test-sqlite-egress", {
+        dbPath: testDbPath,
+        query: "INSERT INTO users (name, email, age) VALUES (?, ?, ?)"
+      });
+
+      expect(node.kind).toBe(NodeKind.Egress);
+      expect(node.name).toBe("test-sqlite-egress");
+      expect(typeof node.run).toBe("function");
+    });
+
+    it("should insert single record", async () => {
+      const node = sqliteEgress("test-insert", {
+        dbPath: testDbPath,
+        query: "INSERT INTO users (name, email, age) VALUES (?, ?, ?)"
+      });
+
+      const input = ["Alice", "alice@example.com", 30];
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(1);
+      expect(result.lastInsertRowid).toBe(1);
+
+      // Verify the record was inserted
+      const verifyDb = new Database(testDbPath);
+      const rows = verifyDb.prepare("SELECT * FROM users").all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toEqual({
+        id: 1,
+        name: "Alice",
+        email: "alice@example.com",
+        age: 30
+      });
+      verifyDb.close();
+    });
+
+    it("should insert multiple records in batch", async () => {
+      const node = sqliteEgress("test-batch-insert", {
+        dbPath: testDbPath,
+        query: "INSERT INTO users (name, email, age) VALUES (?, ?, ?)"
+      });
+
+      const input = [
+        ["Alice", "alice@example.com", 30],
+        ["Bob", "bob@example.com", 25],
+        ["Charlie", "charlie@example.com", 35]
+      ];
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(3);
+
+      // Verify all records were inserted
+      const verifyDb = new Database(testDbPath);
+      const rows = verifyDb.prepare("SELECT * FROM users ORDER BY id").all();
+      expect(rows).toHaveLength(3);
+      expect(rows[0].name).toBe("Alice");
+      expect(rows[1].name).toBe("Bob");
+      expect(rows[2].name).toBe("Charlie");
+      verifyDb.close();
+    });
+
+    it("should handle UPDATE queries", async () => {
+      // First insert a record
+      const insertDb = new Database(testDbPath);
+      insertDb.prepare("INSERT INTO users (name, email, age) VALUES (?, ?, ?)").run("Alice", "alice@example.com", 30);
+      insertDb.close();
+
+      const node = sqliteEgress("test-update", {
+        dbPath: testDbPath,
+        query: "UPDATE users SET age = ? WHERE name = ?"
+      });
+
+      const input = [35, "Alice"];
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(1);
+
+      // Verify the update
+      const verifyDb = new Database(testDbPath);
+      const row = verifyDb.prepare("SELECT age FROM users WHERE name = ?").get("Alice");
+      expect(row).toEqual({ age: 35 });
+      verifyDb.close();
+    });
+
+    it("should handle errors gracefully", async () => {
+      const node = sqliteEgress("test-error", {
+        dbPath: testDbPath,
+        query: "INSERT INTO nonexistent_table (col) VALUES (?)"
+      });
+
+      const effect = node.run(["value"]);
+      
+      await expect(Effect.runPromise(effect)).rejects.toThrow("SQLite egress error");
+    });
+  });
+
+  describe("sqliteInsert", () => {
+    it("should insert record from object", async () => {
+      const node = sqliteInsert("test-object-insert", {
+        dbPath: testDbPath,
+        table: "users"
+      });
+
+      const input = {
+        name: "Alice",
+        email: "alice@example.com",
+        age: 30
+      };
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(1);
+
+      // Verify the record
+      const verifyDb = new Database(testDbPath);
+      const row = verifyDb.prepare("SELECT * FROM users").get();
+      expect(row).toEqual({
+        id: 1,
+        name: "Alice",
+        email: "alice@example.com",
+        age: 30
+      });
+      verifyDb.close();
+    });
+
+    it("should insert multiple records from array of objects", async () => {
+      const node = sqliteInsert("test-array-insert", {
+        dbPath: testDbPath,
+        table: "users"
+      });
+
+      const input = [
+        { name: "Alice", email: "alice@example.com", age: 30 },
+        { name: "Bob", email: "bob@example.com", age: 25 }
+      ];
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(2);
+
+      // Verify the records
+      const verifyDb = new Database(testDbPath);
+      const rows = verifyDb.prepare("SELECT * FROM users ORDER BY id").all();
+      expect(rows).toHaveLength(2);
+      expect(rows[0].name).toBe("Alice");
+      expect(rows[1].name).toBe("Bob");
+      verifyDb.close();
+    });
+
+    it("should handle specified columns", async () => {
+      const node = sqliteInsert("test-columns", {
+        dbPath: testDbPath,
+        table: "users",
+        columns: ["name", "age"]
+      });
+
+      const input = {
+        name: "Alice",
+        email: "alice@example.com", // This should be ignored
+        age: 30,
+        extra: "ignored" // This should be ignored
+      };
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(1);
+
+      // Verify only specified columns were inserted
+      const verifyDb = new Database(testDbPath);
+      const row = verifyDb.prepare("SELECT * FROM users").get();
+      expect(row).toEqual({
+        id: 1,
+        name: "Alice",
+        email: null, // Not inserted
+        age: 30
+      });
+      verifyDb.close();
+    });
+
+    it("should handle conflict resolution", async () => {
+      // First insert a record
+      const insertDb = new Database(testDbPath);
+      insertDb.prepare("INSERT INTO users (name, email, age) VALUES (?, ?, ?)").run("Alice", "alice@example.com", 30);
+      insertDb.close();
+
+      const node = sqliteInsert("test-conflict", {
+        dbPath: testDbPath,
+        table: "users",
+        onConflict: "REPLACE"
+      });
+
+      const input = {
+        name: "Alice Updated",
+        email: "alice@example.com", // This will conflict
+        age: 35
+      };
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(1);
+
+      // Verify the record was replaced
+      const verifyDb = new Database(testDbPath);
+      const row = verifyDb.prepare("SELECT * FROM users").get();
+      expect(row.name).toBe("Alice Updated");
+      expect(row.age).toBe(35);
+      verifyDb.close();
+    });
+  });
+
+  describe("sqliteUpdate", () => {
+    beforeEach(() => {
+      // Insert test data
+      const setupDb = new Database(testDbPath);
+      const stmt = setupDb.prepare("INSERT INTO users (name, email, age) VALUES (?, ?, ?)");
+      stmt.run("Alice", "alice@example.com", 30);
+      stmt.run("Bob", "bob@example.com", 25);
+      setupDb.close();
+    });
+
+    it("should update records", async () => {
+      const node = sqliteUpdate("test-update", {
+        dbPath: testDbPath,
+        table: "users",
+        setClause: "age = ?",
+        whereClause: "name = ?"
+      });
+
+      const input = [35, "Alice"];
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(1);
+
+      // Verify the update
+      const verifyDb = new Database(testDbPath);
+      const alice = verifyDb.prepare("SELECT age FROM users WHERE name = ?").get("Alice");
+      const bob = verifyDb.prepare("SELECT age FROM users WHERE name = ?").get("Bob");
+      expect(alice).toEqual({ age: 35 });
+      expect(bob).toEqual({ age: 25 }); // Unchanged
+      verifyDb.close();
+    });
+
+    it("should update multiple records", async () => {
+      const node = sqliteUpdate("test-bulk-update", {
+        dbPath: testDbPath,
+        table: "users",
+        setClause: "age = age + ?",
+        whereClause: "age > ?"
+      });
+
+      const input = [5, 20]; // Add 5 to age where age > 20
+      const effect = node.run(input);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.success).toBe(true);
+      expect(result.changes).toBe(2); // Both records match
+
+      // Verify the updates
+      const verifyDb = new Database(testDbPath);
+      const rows = verifyDb.prepare("SELECT name, age FROM users ORDER BY name").all();
+      expect(rows).toEqual([
+        { name: "Alice", age: 35 }, // 30 + 5
+        { name: "Bob", age: 30 }    // 25 + 5
+      ]);
+      verifyDb.close();
+    });
+  });
+});

--- a/src/nodes/egress/sqlite.ts
+++ b/src/nodes/egress/sqlite.ts
@@ -1,0 +1,180 @@
+import { Database } from "bun:sqlite";
+import { NodeKind, type Node, Effect } from "../../core/node";
+
+export interface SqliteEgressConfig {
+  readonly dbPath: string;
+  readonly query: string;
+  readonly mode?: "readwrite" | "create";
+  readonly createIfNotExists?: boolean;
+}
+
+export interface SqliteWriteResult {
+  readonly changes: number;
+  readonly lastInsertRowid?: number;
+  readonly success: boolean;
+}
+
+/**
+ * An Egress Node that terminates a pipeline by writing data to a SQLite database.
+ * Uses Bun's native SQLite API for high performance database operations.
+ */
+export function sqliteEgress(
+  name: string,
+  config: SqliteEgressConfig
+): Node<any, SqliteWriteResult> {
+  return {
+    kind: NodeKind.Egress,
+    name,
+    run: (input: any) => {
+      return Effect.tryPromise({
+        try: async () => {
+          const db = new Database(config.dbPath);
+          
+          try {
+            const stmt = db.prepare(config.query);
+            
+            // Handle different input types
+            let result;
+            if (Array.isArray(input) && input.length > 0 && Array.isArray(input[0])) {
+              // Batch operation - array of parameter arrays
+              result = db.transaction(() => {
+                let totalChanges = 0;
+                let lastId;
+                for (const params of input) {
+                  const res = stmt.run(...params);
+                  totalChanges += res.changes;
+                  lastId = res.lastInsertRowid;
+                }
+                return { changes: totalChanges, lastInsertRowid: lastId };
+              })();
+            } else if (Array.isArray(input)) {
+              // Single operation with array of parameters
+              result = stmt.run(...input);
+            } else {
+              // Single operation with single parameter or object
+              result = stmt.run(input);
+            }
+            
+            return {
+              changes: result.changes,
+              lastInsertRowid: result.lastInsertRowid,
+              success: true
+            };
+          } finally {
+            db.close();
+          }
+        },
+        catch: (error) => new Error(`SQLite egress error: ${error}`)
+      });
+    }
+  };
+}
+
+/**
+ * A specialized SQLite egress node for INSERT operations.
+ */
+export function sqliteInsert(
+  name: string,
+  config: {
+    readonly dbPath: string;
+    readonly table: string;
+    readonly columns?: string[];
+    readonly mode?: "readwrite" | "create";
+    readonly createIfNotExists?: boolean;
+    readonly onConflict?: "IGNORE" | "REPLACE" | "ABORT" | "FAIL" | "ROLLBACK";
+  }
+): Node<Record<string, any> | Record<string, any>[], SqliteWriteResult> {
+  return {
+    kind: NodeKind.Egress,
+    name,
+    run: (input: Record<string, any> | Record<string, any>[]) => {
+      return Effect.tryPromise({
+        try: async () => {
+          const db = new Database(config.dbPath);
+          
+          try {
+            // Get the first record to determine columns if not specified
+            const firstRecord = Array.isArray(input) ? input[0] : input;
+            const columns = config.columns || Object.keys(firstRecord);
+            const placeholders = columns.map(() => '?').join(', ');
+            
+            const conflictClause = config.onConflict ? ` OR ${config.onConflict}` : '';
+            const query = `INSERT${conflictClause} INTO ${config.table} (${columns.join(', ')}) VALUES (${placeholders})`;
+            
+            const stmt = db.prepare(query);
+            
+            let result;
+            if (Array.isArray(input)) {
+              // Batch insert
+              result = db.transaction(() => {
+                let totalChanges = 0;
+                let lastId;
+                for (const record of input) {
+                  const values = columns.map(col => record[col]);
+                  const res = stmt.run(...values);
+                  totalChanges += res.changes;
+                  lastId = res.lastInsertRowid;
+                }
+                return { changes: totalChanges, lastInsertRowid: lastId };
+              })();
+            } else {
+              // Single insert
+              const values = columns.map(col => firstRecord[col]);
+              result = stmt.run(...values);
+            }
+            
+            return {
+              changes: result.changes,
+              lastInsertRowid: result.lastInsertRowid,
+              success: true
+            };
+          } finally {
+            db.close();
+          }
+        },
+        catch: (error) => new Error(`SQLite insert error: ${error}`)
+      });
+    }
+  };
+}
+
+/**
+ * A specialized SQLite egress node for UPDATE operations.
+ */
+export function sqliteUpdate(
+  name: string,
+  config: {
+    readonly dbPath: string;
+    readonly table: string;
+    readonly setClause: string;
+    readonly whereClause: string;
+    readonly mode?: "readwrite" | "create";
+  }
+): Node<any, SqliteWriteResult> {
+  return {
+    kind: NodeKind.Egress,
+    name,
+    run: (input: any) => {
+      return Effect.tryPromise({
+        try: async () => {
+          const db = new Database(config.dbPath);
+          
+          try {
+            const query = `UPDATE ${config.table} SET ${config.setClause} WHERE ${config.whereClause}`;
+            const stmt = db.prepare(query);
+            const result = stmt.run(...input);
+            
+            return {
+              changes: result.changes,
+              lastInsertRowid: result.lastInsertRowid,
+              success: true
+            };
+          } finally {
+            db.close();
+          }
+        },
+        catch: (error) => new Error(`SQLite update error: ${error}`)
+      });
+    }
+  };
+}

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -1,6 +1,7 @@
 // Ingress nodes
 export * from "./ingress/http";
 export { httpServer, type HttpServerConfig } from "./ingress/httpServer";
+export { sqliteIngress, sqliteSelect, type SqliteIngressConfig, type SqliteQueryResult } from "./ingress/sqlite";
 
 // Transform nodes  
 export * from "./transform/mapJson";
@@ -10,6 +11,7 @@ export { batch, type BatchConfig } from "./transform/batch";
 // Egress nodes
 export * from "./egress/http";
 export { httpResponse, type HttpResponseConfig } from "./egress/httpResponse";
+export { sqliteEgress, sqliteInsert, sqliteUpdate, type SqliteEgressConfig, type SqliteWriteResult } from "./egress/sqlite";
 
 // Duplex nodes
 export * from "./duplex/echo"; 

--- a/src/nodes/ingress/sqlite.test.ts
+++ b/src/nodes/ingress/sqlite.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Effect } from "effect";
+import { sqliteIngress, sqliteSelect } from "./sqlite";
+import { NodeKind } from "../../core/node";
+
+describe("SQLite Ingress Nodes", () => {
+  const testDbPath = "test.db";
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(testDbPath);
+    // Drop and recreate table to ensure clean state
+    db.exec("DROP TABLE IF EXISTS users");
+    db.exec(`
+      CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        email TEXT UNIQUE,
+        age INTEGER
+      )
+    `);
+    
+    const insertStmt = db.prepare("INSERT INTO users (name, email, age) VALUES (?, ?, ?)");
+    insertStmt.run("Alice", "alice@example.com", 30);
+    insertStmt.run("Bob", "bob@example.com", 25);
+    insertStmt.run("Charlie", "charlie@example.com", 35);
+    db.close();
+  });
+
+  describe("sqliteIngress", () => {
+    it("should create a node with correct properties", () => {
+      const node = sqliteIngress("test-sqlite", {
+        dbPath: testDbPath,
+        query: "SELECT * FROM users"
+      });
+
+      expect(node.kind).toBe(NodeKind.Ingress);
+      expect(node.name).toBe("test-sqlite");
+      expect(typeof node.run).toBe("function");
+    });
+
+    it("should execute SELECT query and return results", async () => {
+      const node = sqliteIngress("test-select", {
+        dbPath: testDbPath,
+        query: "SELECT * FROM users ORDER BY id"
+      });
+
+      const effect = node.run(undefined);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.rows).toHaveLength(3);
+      expect(result.rows[0]).toEqual({
+        id: 1,
+        name: "Alice",
+        email: "alice@example.com",
+        age: 30
+      });
+    });
+
+    it("should execute parameterized query", async () => {
+      const node = sqliteIngress("test-params", {
+        dbPath: testDbPath,
+        query: "SELECT * FROM users WHERE age > ?",
+        params: [30]
+      });
+
+      const effect = node.run(undefined);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].name).toBe("Charlie");
+    });
+
+    it("should handle named parameters", async () => {
+      const node = sqliteIngress("test-named-params", {
+        dbPath: testDbPath,
+        query: "SELECT * FROM users WHERE name = $name",
+        params: { $name: "Bob" }
+      });
+
+      const effect = node.run(undefined);
+      const result = await Effect.runPromise(effect);
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].name).toBe("Bob");
+    });
+
+    it("should handle errors gracefully", async () => {
+      const node = sqliteIngress("test-error", {
+        dbPath: testDbPath,
+        query: "SELECT * FROM nonexistent_table"
+      });
+
+      const effect = node.run(undefined);
+      
+      await expect(Effect.runPromise(effect)).rejects.toThrow("SQLite ingress error");
+    });
+  });
+
+  describe("sqliteSelect", () => {
+    it("should return just the rows array", async () => {
+      const node = sqliteSelect("test-select-simple", {
+        dbPath: testDbPath,
+        query: "SELECT name, age FROM users ORDER BY age"
+      });
+
+      const effect = node.run(undefined);
+      const result = await Effect.runPromise(effect);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({ name: "Bob", age: 25 });
+      expect(result[1]).toEqual({ name: "Alice", age: 30 });
+      expect(result[2]).toEqual({ name: "Charlie", age: 35 });
+    });
+
+    it("should work with parameters", async () => {
+      const node = sqliteSelect("test-select-params", {
+        dbPath: testDbPath,
+        query: "SELECT name FROM users WHERE age BETWEEN ? AND ?",
+        params: [25, 30]
+      });
+
+      const effect = node.run(undefined);
+      const result = await Effect.runPromise(effect);
+
+      expect(result).toHaveLength(2);
+      expect(result.map(r => r.name)).toEqual(["Alice", "Bob"]);
+    });
+
+    it("should return empty array for no results", async () => {
+      const node = sqliteSelect("test-empty", {
+        dbPath: testDbPath,
+        query: "SELECT * FROM users WHERE age > 100"
+      });
+
+      const effect = node.run(undefined);
+      const result = await Effect.runPromise(effect);
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/src/nodes/ingress/sqlite.ts
+++ b/src/nodes/ingress/sqlite.ts
@@ -1,0 +1,88 @@
+import { Database } from "bun:sqlite";
+import { NodeKind, type Node, Effect } from "../../core/node";
+
+export interface SqliteIngressConfig {
+  readonly dbPath: string;
+  readonly query: string;
+  readonly params?: Record<string, any> | any[];
+  readonly mode?: "readonly" | "readwrite" | "create";
+}
+
+export interface SqliteQueryResult {
+  readonly rows: any[];
+  readonly changes?: number;
+  readonly lastInsertRowid?: number;
+}
+
+/**
+ * An Ingress Node that starts a pipeline by reading data from a SQLite database.
+ * Uses Bun's native SQLite API for high performance database operations.
+ */
+export function sqliteIngress(
+  name: string,
+  config: SqliteIngressConfig
+): Node<undefined, SqliteQueryResult> {
+  return {
+    kind: NodeKind.Ingress,
+    name,
+    run: () => {
+      return Effect.tryPromise({
+        try: async () => {
+          const db = new Database(config.dbPath);
+          
+          try {
+            const stmt = db.prepare(config.query);
+            
+            // For SELECT queries, we only need the rows
+            const rows = config.params 
+              ? stmt.all(config.params)
+              : stmt.all();
+            
+            return {
+              rows,
+              changes: 0,  // Not meaningful for SELECT queries
+              lastInsertRowid: undefined  // Not meaningful for SELECT queries
+            };
+          } finally {
+            db.close();
+          }
+        },
+        catch: (error) => new Error(`SQLite ingress error: ${error}`)
+      });
+    }
+  };
+}
+
+/**
+ * A specialized SQLite ingress node for SELECT queries that returns just the rows.
+ */
+export function sqliteSelect(
+  name: string,
+  config: Omit<SqliteIngressConfig, 'mode'> & { mode?: "readonly" }
+): Node<undefined, any[]> {
+  return {
+    kind: NodeKind.Ingress,
+    name,
+    run: () => {
+      return Effect.tryPromise({
+        try: async () => {
+          const dbOptions: any = {};
+          if (config.dbPath !== ":memory:") {
+            dbOptions.readonly = true;
+          }
+          const db = new Database(config.dbPath, dbOptions);
+          
+          try {
+            const stmt = db.prepare(config.query);
+            return config.params 
+              ? stmt.all(config.params)
+              : stmt.all();
+          } finally {
+            db.close();
+          }
+        },
+        catch: (error) => new Error(`SQLite select error: ${error}`)
+      });
+    }
+  };
+}


### PR DESCRIPTION
Add Bun native SQLite ingress and egress nodes to enable high-performance database interactions within pipelines.

This implementation addresses complexities in correctly integrating Bun's native SQLite API, particularly around parameter passing for single and batch operations, and ensuring proper Effect integration for robust error handling and async execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ab047f6-81cd-40df-b68a-7eb6d629eff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ab047f6-81cd-40df-b68a-7eb6d629eff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>